### PR TITLE
Feature: SAN-15 Add case and accent insensitive search bar on the products page

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md border border-orange-200 bg-background",
+        "px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent",
+        "file:text-sm file:font-medium placeholder:text-orange-700",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500",
+        "focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Related Issue
[SAN-15](https://santiscl.atlassian.net/browse/SAN-15)

## Problem
- The catalog is extending too much and it has become too difficult to find a product

## Solution
- Added a search bar
- When nothing is prompted it loads all the products
- When there is a prompt it loads the products that match some part of the name

## How to test
- Go to products page `/products`
- Verify the bar is there
- Verify that all the products load when nothing is prompted in the search bar
- Verify that the search bar query works properly